### PR TITLE
fix: different links for openapi and graphql for xyd

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Assist users in understanding and navigating the features and functionalities of
 - [Scalar](https://github.com/scalar/scalar) - Generate interactive API documentations from Swagger files.
 - [OpenAPI Generator](https://github.com/OpenAPITools/openapi-generator) - Generate API client libraries (SDK generation), server stubs, documentation and configuration automatically given an OpenAPI Spec (v2, v3).
 - [GitBook](https://github.com/GitbookIO/gitbook) - A modern platform for creating and managing interactive API documentation from OpenAPI definitions.
+- [xyd](https://xyd.dev/docs/guides/openapi) - Generate scalable API Docs from OpenAPI definitions easier.
 
 #### GraphQL
 
@@ -161,6 +162,7 @@ Assist users in understanding and navigating the features and functionalities of
 - [SpectaQL](https://github.com/anvilco/spectaql) - A Node.js library that generates static documentation for a GraphQL schema.
 - [GraphQLDocs](https://github.com/brettchalupa/graphql-docs) - Ruby library and CLI for easily generating beautiful documentation from your GraphQL schema.
 - [Magidoc](https://github.com/magidoc-org/magidoc) - A  a JavaScript library that auto-generates static documentation from any GraphQL schema.
+- [xyd](https://xyd.dev/docs/guides/graphql) - Generate scalable API Docs from GraphQL schema easier.
 
 #### gRPC
 


### PR DESCRIPTION
Hi,

First of all, thank you for the previous merge! 

I saw that you had to fix links because of lint issues. While it's ok for us would be better to mention xyd as GraphQL and OpenAPI generators too. I fixed links to make lint happy.

Best,