### PR TITLE
Add Jamdesk to Site Builder section

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ README files are a staple of any code project. They provide the first introducti
 - [Docus](https://github.com/nuxt-themes/docus) ![GitHub Repo stars](https://img.shields.io/github/stars/nuxt-themes/docus) - Create document-driven websites with Vue & Markdown.
 - [Doctave](https://github.com/Doctave/doctave) ![GitHub Repo stars](https://img.shields.io/github/stars/Doctave/doctave) - A batteries-included developer documentation site generator.
 - [xyd](https://github.com/livesession/xyd) ![GitHub Repo stars](https://img.shields.io/github/stars/livesession/xyd) - A new scalable docs framework built for everyone powered by LiveSession.
+- [Jamdesk](https://jamdesk.com/) - A documentation platform that uses MDX for authoring, with built-in OpenAPI references, AI chat, custom domains, and a CLI for local development.
 
 ### Wiki Builder
 


### PR DESCRIPTION
Adding Jamdesk to the Site Builder section.

I'm Geoff, one of the co-founders. Jamdesk is an MDX-based documentation platform with a CLI for local previews. You push to GitHub, and it builds and deploys automatically. It also handles OpenAPI references, has AI-powered chat, and supports custom domains.

Our own docs run on it: https://jamdesk.com/docs

Added to the bottom of the section per the contributing guidelines. Thanks for maintaining such a thorough list!