### PR TITLE
Add NRG to Code Documentation > README

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ README files are a staple of any code project. They provide the first introducti
 - [Awesome README](https://github.com/matiassingers/awesome-readme) ![GitHub Repo stars](https://img.shields.io/github/stars/matiassingers/awesome-readme) - A curated list of awesome READMEs, including examples, articles and tools.
 - [README template](https://gitlab.com/tgdp/templates/-/blob/main/readme/template-readme.md) - Open-source template provided by The Good Docs Project.
 - [readme.so](https://github.com/octokatherine/readme.so) ![GitHub Repo stars](https://img.shields.io/github/stars/octokatherine/readme.so) - An online drag-and-drop editor to easily build READMEs.
+- [NRG](https://github.com/nanolaba/readme-generator) ![GitHub Repo stars](https://img.shields.io/github/stars/nanolaba/readme-generator) - Multi-language README generator that builds README files from a single `.src.md` template with imports, widgets, and a table-of-contents engine. CLI, Maven plugin, and Java library.
 
 #### Comments
 


### PR DESCRIPTION
Adds NRG (Nanolaba Readme Generator) to the `Code Documentation > README` section.

NRG generates multi-language README files (e.g. `README.md` and `README.ru.md`) from a single `.src.md` template via imports, custom widgets, and a built-in TOC widget. Distributed as a CLI, Maven plugin, and Java library.

- Repo: https://github.com/nanolaba/readme-generator
- Maven Central: https://central.sonatype.com/artifact/com.nanolaba/readme-generator

Adheres to the contribution guidelines: fits the existing `README` subsection, appended to the bottom of the list, single suggestion per PR, matches the `[Name](url) ![GitHub Repo stars](...) - Description.` format used by neighboring entries.