### PR TITLE
Add Sourcey to Site Builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ README files are a staple of any code project. They provide the first introducti
 - [Docus](https://github.com/nuxt-themes/docus) ![GitHub Repo stars](https://img.shields.io/github/stars/nuxt-themes/docus) - Create document-driven websites with Vue & Markdown.
 - [Doctave](https://github.com/Doctave/doctave) ![GitHub Repo stars](https://img.shields.io/github/stars/Doctave/doctave) - A batteries-included developer documentation site generator.
 - [xyd](https://github.com/livesession/xyd) ![GitHub Repo stars](https://img.shields.io/github/stars/livesession/xyd) - A new scalable docs framework built for everyone powered by LiveSession.
+- [Sourcey](https://github.com/sourcey/sourcey) ![GitHub Repo stars](https://img.shields.io/github/stars/sourcey/sourcey) - Multi-source static documentation generator. Consumes OpenAPI, MCP, Doxygen XML, godoc, and Markdown to produce one static HTML site. Self-hosted, AGPL-3.0.
 
 ### Wiki Builder
 


### PR DESCRIPTION
Sourcey (https://sourcey.com) is an open-source static documentation generator that consumes OpenAPI, MCP server manifests, Doxygen XML, godoc, and Markdown sources and produces a single static HTML site. AGPL-3.0 on the CLI; self-host anywhere.

Fits the Site Builder section alongside Docusaurus, MkDocs, Sphinx, and Starlight as the multi-source option.

- Project: https://sourcey.com
- Source: https://github.com/sourcey/sourcey
- License: AGPL-3.0

The entry follows this list's existing format which uses GitHub URLs to support the star-count badge alongside each project.