### PR TITLE
Add Biel.ai to Commercial

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ Documentation can be more than just plain texts and static pictures.
 from project plans, to specs and process documentation.
 - [Swimm document](https://swimm.io/document) - Code documentation for developer productivity, including AI support to improve readability.
 - [Kapa.ai](https://kapa.ai/) - Generate an LLM-powered chatbot that answers developer questions automatically and helps you find gaps in your docs.
+- [Biel.ai](https://biel.ai/) - An AI assistant for technical documentation that answers user questions with source-cited responses, on your docs site, in Slack and Teams, or in AI tools via MCP.
 
 ## More Topics
 


### PR DESCRIPTION
Adds [Biel.ai](https://biel.ai) to the Commercial section: an AI assistant for technical documentation with source-cited answers, available as a docs-site widget, Slack/Teams bots, and via MCP for AI tools. Added at the bottom of the section per the contribution guidelines.