### PR TITLE
Add CodeAlmanac

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ README files are a staple of any code project. They provide the first introducti
 - [Mintlify Writer](https://github.com/mintlify/writer) ![GitHub Repo stars](https://img.shields.io/github/stars/mintlify/writer) - An AI-powered VS Code extension that automatically generates code documentation by highlighting code. Supports multiple programming languages and docstring formats including JSDoc, reST, NumPy, and more.
 - [Readme AI](https://github.com/eli64s/readme-ai) ![GitHub Repo stars](https://img.shields.io/github/stars/eli64s/readme-ai) - A developer tool that automatically generates comprehensive README files using repository analysis and language models. It supports multiple LLM providers, custom templates, and offline generation.
 - [GitBook AI](https://www.gitbook.com/solutions/ai) - A built-in AI assistant that helps teams quickly draft, refine, and enhance product documentation with smart, context-aware suggestions.
+- [CodeAlmanac](https://github.com/AlmanacCode/codealmanac) ![GitHub Repo stars](https://img.shields.io/github/stars/AlmanacCode/codealmanac) - Self-updating repository wiki for AI coding agents that tracks project conversations and context locally in the repo.
 
 ### Checker & Formatter
 


### PR DESCRIPTION
Adds CodeAlmanac to the AI-powered Tools section.

Why it fits:
- self-updating repository wiki for AI coding agents
- tracks project conversations and context locally in the repo
- public open-source project

Validation:
- read CONTRIBUTING.md
- added one item to an existing section
- ran `git diff --check`
- ran `uvx pre-commit run --all-files`
