### PR TITLE
Add independent documentation QA sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ README files are a staple of any code project. They provide the first introducti
   - [Performance Test Report Template](https://www.perfmatrix.com/performance-test-report-template/) - A free .docx template for performance test report from PerfMatrix.
   - [Performance Testing Results Report: How to Write It (with Example)](https://u-tor.com/topic/performance-testing-report) - A guide on performance testing report, including why, how and a real world example.
   - [A Step-by-Step Guide to Creating a Powerful Performance Summary Report](https://www.linkedin.com/pulse/step-by-step-guide-creating-powerful-performance-summary-james-ohia/) - Discuss the best practices for creating a performance test summary report and the key components that should be included in it, with a full example.
+  - [Independent AI Output and Website Trust QA Sample](https://chris-saas-services.stomeonst123.chatgpt.site/resources/ai-output-website-trust-qa-sample) - A dated public documentation QA report with source-linked evidence, bounded fixes, a retest checklist, and explicit access limits.
 
 ### Other Types
 


### PR DESCRIPTION
## Summary

Adds one resource to **Test Documentation > Test Report**:

* an independent, dated documentation QA sample
* source-linked evidence
* bounded repair recommendations
* a public retest checklist
* explicit access and conclusion limits

## Disclosure

I maintain the linked LaunchClear sample, and the page also provides a path to a paid fixed-scope QA service. The directory entry itself is neutral and contains no price or promotional claim. LangBot did not commission, review, or endorse the sample, and there is no client relationship.

## Checks

* Added one item at the bottom of the existing Test Report list
* Confirmed the public English sample returns HTTP 200 on July 16, 2026
* Reviewed the diff for spelling, grammar, and duplicate placement