### PR TITLE
Add wiki to Wiki Builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ README files are a staple of any code project. They provide the first introducti
 - [Federated Wiki](https://www.wikiwand.com/en/Federated_Wiki)
   - [The Federated Wiki](https://www.writethedocs.org/videos/na/2015/keynote-the-federated-wiki-ward-cunningham/) - Use federation to ease sharing, by Ward Cunningham.
   - [Node.js server version](https://github.com/fedwiki/wiki) ![GitHub Repo stars](https://img.shields.io/github/stars/fedwiki/wiki) - Federated Wiki node server as npm package.
+- [wiki](https://github.com/plasma-ai/wiki) ![GitHub Repo stars](https://img.shields.io/github/stars/plasma-ai/wiki) - Build and maintain indexed Markdown knowledge bases with generated hierarchical indexes, cross-links, and scoped CLI commands for agents.
 
 ### Knowledge Base
 


### PR DESCRIPTION
Adds [wiki](https://github.com/plasma-ai/wiki) to **Wiki Builder**.

wiki is an Apache-2.0 Python CLI for building and maintaining indexed Markdown knowledge bases. It generates hierarchical indexes and cross-links and gives agents scoped commands to map, search, read, update, and lint the knowledge base.

The entry is added to the bottom of the existing section as required and uses the list's dynamic GitHub star badge.

The project currently has 63 stars and six forks, with documentation at https://docs.plasma.ai/wiki and a published package at https://pypi.org/project/plasma-wiki/. It is also included in the focused [Awesome LLM Wiki](https://github.com/gavischneider/awesome-llm-wiki) list.

Disclosure: I'm affiliated with the project.