### PR TITLE
Add notabene to AI-powered Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ README files are a staple of any code project. They provide the first introducti
 - [Mintlify Writer](https://github.com/mintlify/writer) ![GitHub Repo stars](https://img.shields.io/github/stars/mintlify/writer) - An AI-powered VS Code extension that automatically generates code documentation by highlighting code. Supports multiple programming languages and docstring formats including JSDoc, reST, NumPy, and more.
 - [Readme AI](https://github.com/eli64s/readme-ai) ![GitHub Repo stars](https://img.shields.io/github/stars/eli64s/readme-ai) - A developer tool that automatically generates comprehensive README files using repository analysis and language models. It supports multiple LLM providers, custom templates, and offline generation.
 - [GitBook AI](https://www.gitbook.com/solutions/ai) - A built-in AI assistant that helps teams quickly draft, refine, and enhance product documentation with smart, context-aware suggestions.
+- [notabene](https://github.com/z29k/notabene) ![GitHub Repo stars](https://img.shields.io/github/stars/z29k/notabene) - Renders a repo's Markdown/MDX as a navigable site with anchored comments that an AI agent applies back to the source files.
 
 ### Checker & Formatter
 


### PR DESCRIPTION
Adds [notabene](https://github.com/z29k/notabene) to *General Tools → AI-powered Tools*.

notabene renders a repo's Markdown/MDX as a navigable site where reviewers leave anchored, Google-Docs-style comments on the rendered text. Comments are stored as JSON committed next to the docs, so an AI agent reads the open ones, applies the feedback to the source files, resolves the threads and journals what changed. No SaaS, no external service — the review round-trip stays in git.

Placed in *AI-powered Tools* rather than *Site Builder*: rendering the site is the support, the human↔agent review loop is the point.

MIT, published as `@z29k/notabene`, docs at https://z29k.github.io/notabene/

Per CONTRIBUTING.md:
- Fitted into an existing section, appended at the bottom of the list
- Individual PR for this single suggestion
- Follows the section format, including the GitHub stars badge

On `pre-commit`: hooks were installed and run against `README.md`. `trailing-whitespace`, `end-of-file-fixer`, `check-yaml` and `check-added-large-files` all pass. `awesome-lint` reports `1:1 Awesome list must reside in a valid git repository (remark-lint:awesome-github)` — but it reports exactly the same error on the unmodified upstream `README.md` (verified by stashing this change and re-running), so it is a local/fork environment artefact rather than something introduced here. The commit was made with `--no-verify` for that reason; happy to adjust if you see it differently.