### PR TITLE
Add Notula to Commercial

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ Documentation can be more than just plain texts and static pictures.
 from project plans, to specs and process documentation.
 - [Swimm document](https://swimm.io/document) - Code documentation for developer productivity, including AI support to improve readability.
 - [Kapa.ai](https://kapa.ai/) - Generate an LLM-powered chatbot that answers developer questions automatically and helps you find gaps in your docs.
+- [Notula](https://notula.org) - A WYSIWYG Markdown editor for docs as code, where the whole team reads, edits and comments on the documentation in a git repository. Comment threads are committed beside the documents rather than written into the Markdown. Free, macOS and Windows.
 
 ## More Topics
 

--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ Documentation can be more than just plain texts and static pictures.
 from project plans, to specs and process documentation.
 - [Swimm document](https://swimm.io/document) - Code documentation for developer productivity, including AI support to improve readability.
 - [Kapa.ai](https://kapa.ai/) - Generate an LLM-powered chatbot that answers developer questions automatically and helps you find gaps in your docs.
-- [Notula](https://notula.org) - A WYSIWYG Markdown editor for docs as code, where the whole team reads, edits and comments on the documentation in a git repository. Comment threads are committed beside the documents rather than written into the Markdown. Free, macOS and Windows.
+- [Notula](https://notula.org) - WYSIWYG editor for the Markdown documentation in a git repository, with comment threads committed beside the documents.
 
 ## More Topics
 


### PR DESCRIPTION
Adds **Notula** to the bottom of General Tools / Commercial.

Notula is a free desktop editor for the Markdown documentation that already lives in a git repository. It shows the repository as a tree of documents rather than a file list, edits them WYSIWYG with no syntax on screen, and adds a review layer: comment on a passage, reply, mention, resolve. The threads are committed next to the documents as plain files, so they arrive with a clone and nothing is written into the Markdown itself. macOS and Windows, no account and no server.

Commercial rather than Knowledge Base: the app is closed source, which is how this list already treats Writerside and Confluence, and Knowledge Base is open-source self-hosted wikis.

Checked against CONTRIBUTING.md: one item in one pull request, fitted into an existing section, added at the bottom of it, `- [Name](link) - Description.` format ending in a full stop, and `README.md` only - `README_zh.md` is synced separately, as in #16.

I work on Notula.
