### PR TITLE
Add Reasoning Formats to Architectural Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Assist users in understanding and navigating the features and functionalities of
 
 - [Log4brains](https://github.com/thomvaill/log4brains) ![GitHub Repo stars](https://img.shields.io/github/stars/thomvaill/log4brains) - Log Architecture Decision Records (ADR) right from your IDE and to publish them automatically as a static website.
 - [Design Docs at Google](https://www.industrialempathy.com/posts/design-docs-at-google/) - Overview of how software design docs are used and written at Google.
+- [Reasoning Formats](https://github.com/reasoning-formats/reasoning-formats) ![GitHub Repo stars](https://img.shields.io/github/stars/reasoning-formats/reasoning-formats) - Machine-readable YAML formats for decision records (DRF) and the organizational context they are validated against (CRF), both defined by JSON Schema.
 
 ### API Documentation
 


### PR DESCRIPTION
Adds one entry to the bottom of **Documentation Types → Architectural Documentation**:

```
- [Reasoning Formats](https://github.com/reasoning-formats/reasoning-formats) ![GitHub Repo stars](https://img.shields.io/github/stars/reasoning-formats/reasoning-formats) - Machine-readable YAML formats for decision records (DRF) and the organizational context they are validated against (CRF), both defined by JSON Schema.
```

**Fit with the section.** The section covers arc42 and C4 for structure and diagrams, and Log4brains for ADRs as docs-as-code. This adds the schema-first angle to decision documentation: a decision is a YAML document validated against a JSON Schema, with the reasoning in named fields - constraints, objectives, assumptions, tensions, synthesis - instead of prose under headings. That makes the trade-off analysis queryable and lets CI reject an internally inconsistent record, for example one marked `approved` with no synthesis. A companion format (CRF) models organizational context - policies, systems, facts - as a graph decisions reference, so a decision can be checked against the policies in force when it was written.

**Housekeeping:**
- Fitted into an existing section, no new section proposed.
- Individual PR for this single item, appended at the bottom of the list.
- Star badge included to match the section style.
- Ran `pre-commit run --files README.md`: trailing-whitespace, end-of-file-fixer, check-yaml and check-added-large-files all pass. `awesome-lint` reports `Awesome list must reside in a valid git repository` - this also fires on the unmodified upstream README inside a fork clone, so it is an artifact of the fork name rather than this change. Happy to adjust if it behaves differently in your CI.

**Disclosure:** I am the author of the format. Apache-2.0, draft v0.3.0, tagged release with published schemas and CI that validates every example plus 24 fixtures asserting malformed documents are rejected.